### PR TITLE
Artifact support

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -80,6 +80,7 @@ func (rc *RunContext) GetBindsAndMounts() ([]string, map[string]string) {
 
 	mounts := map[string]string{
 		"act-toolcache": "/toolcache",
+		"act-artifacts-" + rc.Config.RunID: "/artifacts",
 	}
 
 	if rc.Config.BindWorkdir {

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -226,7 +226,7 @@ func (rc *RunContext) Executor() common.Executor {
 	steps = append(steps, rc.stopJobContainer())
 
 	return common.NewPipelineExecutor(steps...).
-		Finally(rc.stopJobContainer()).
+		Finally(rc.stopJobContainer().IfBool(rc.Config.AutoRemove)).
 		If(rc.isEnabled)
 }
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -157,10 +157,10 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 				return nil
 			}
 			artifactVolume := "act-artifacts-" + runner.config.RunID
-			log.Infof("[[[]]] Cleaning up artifacts volume \"%s\"", artifactVolume)
+			log.Infof("Cleaning up artifacts volume \"%s\"", artifactVolume)
 			err := container.NewDockerVolumeRemoveExecutor(artifactVolume, false)(ctx)
 			if err != nil {
-				log.Infof("[[[]]] Error cleaning up volume \"%s\": %v", artifactVolume, err)
+				log.Errorf("Error cleaning up volume \"%s\": %v", artifactVolume, err)
 			}
 			return err
 		})

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/nektos/act/pkg/common"
+	"github.com/nektos/act/pkg/container"
 	"github.com/nektos/act/pkg/model"
 	log "github.com/sirupsen/logrus"
 )
@@ -150,7 +151,19 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 		pipeline = append(pipeline, common.NewParallelExecutor(stageExecutor...))
 	}
 
-	return common.NewPipelineExecutor(pipeline...)
+	return common.NewPipelineExecutor(pipeline...).
+		Finally(func(ctx context.Context) error {
+			if !runner.config.AutoRemove {
+				return nil
+			}
+			artifactVolume := "act-artifacts-" + runner.config.RunID
+			log.Infof("[[[]]] Cleaning up artifacts volume \"%s\"", artifactVolume)
+			err := container.NewDockerVolumeRemoveExecutor(artifactVolume, false)(ctx)
+			if err != nil {
+				log.Infof("[[[]]] Error cleaning up volume \"%s\": %v", artifactVolume, err)
+			}
+			return err
+		})
 }
 
 func (runner *runnerImpl) newRunContext(run *model.Run, matrix map[string]interface{}) *RunContext {


### PR DESCRIPTION
- Adds a mount for each workflow run to hold artifacts for that run
  - The volume name is `act-artifacts-[runid]`, mounted in the container at `/artifacts`.
- Only remove a job container if the job succeeds or if `--rm` is passed to the runner