### PR TITLE
Put scripts in `/tmp` instead of working directory

### DIFF
--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -227,7 +227,7 @@ func (sc *StepContext) setupShellCommand() common.Executor {
 		run = runPrepend + "\n" + run + "\n" + runAppend
 
 		log.Debugf("Wrote command '%s' to '%s'", run, scriptName)
-		scriptPath := fmt.Sprintf("%s/%s", rc.Config.ContainerWorkdir(), scriptName)
+		scriptPath := fmt.Sprintf("/tmp/%s", scriptName)
 
 		if step.Shell == "" {
 			step.Shell = rc.Run.Job().Defaults.Run.Shell
@@ -252,7 +252,7 @@ func (sc *StepContext) setupShellCommand() common.Executor {
 
 		sc.Cmd = finalCMD
 
-		return rc.JobContainer.Copy(rc.Config.ContainerWorkdir(), &container.FileEntry{
+		return rc.JobContainer.Copy("/tmp/", &container.FileEntry{
 			Name: scriptName,
 			Mode: 0755,
 			Body: script.String(),


### PR DESCRIPTION
The main fork of `act` puts scripts inside a folder in a container's working directory. This is problematic for some actions which expect the working directory to have a specific structure. For instance, `apache/dubbo`'s [Build and Test For Dubbo 3](https://github.com/apache/dubbo/blob/e2a9d71271fc0ee218733b46e3a3c9aab402293c/.github/workflows/build-and-test-3.yml#L96) workflow ensures that each file has an appropriate license header; since the scripts that `act` writes do not have such headers, the workflow fails. This PR makes `act` put scripts inside the `/tmp/` directory in order to keep the working directory clean.