### PR TITLE
Bugfixes

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -575,7 +575,7 @@ func (rc *RunContext) getGithubContext() *githubContext {
 	return ghc
 }
 
-func (ghc *githubContext) isLocalCheckout(step *model.Step) bool {
+func (ghc *githubContext) isLocalCheckout(step *model.Step, ee ExpressionEvaluator) bool {
 	if step.Type() == model.StepTypeInvalid {
 		// This will be errored out by the executor later, we need this here to avoid a null panic though
 		return false
@@ -595,8 +595,11 @@ func (ghc *githubContext) isLocalCheckout(step *model.Step) bool {
 	if repository, ok := step.With["repository"]; ok && repository != ghc.Repository {
 		return false
 	}
-	if repository, ok := step.With["ref"]; ok && repository != ghc.Ref {
-		return false
+	if ref, ok := step.With["ref"]; ok {
+		interp, ok2 := ee.InterpolateWithStringCheck(ref)
+		if ok2 && interp != ghc.Ref {
+			return false
+		}
 	}
 	return true
 }
@@ -711,7 +714,7 @@ func (rc *RunContext) withGithubEnv(env map[string]string) map[string]string {
 func (rc *RunContext) localCheckoutPath() (string, bool) {
 	ghContext := rc.getGithubContext()
 	for _, step := range rc.Run.Job().Steps {
-		if ghContext.isLocalCheckout(step) {
+		if ghContext.isLocalCheckout(step, rc.ExprEval) {
 			return step.With["path"], true
 		}
 	}

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -75,7 +75,10 @@ func (rc *RunContext) GetBindsAndMounts() ([]string, map[string]string) {
 	}
 
 	binds := []string{
-		fmt.Sprintf("%s:%s", rc.Config.ContainerDaemonSocket, "/var/run/docker.sock"),
+		// ***DO NOT BIND '/var/run/docker.sock'!*** If you do, then you're giving the runner image, running code
+		// scraped from the internet, access to docker ON THE HOST MACHINE.
+		// (I've already come across a workflow that runs 'docker image prune -af'. That was a nasty shock.  --Robert)
+		// fmt.Sprintf("%s:%s", rc.Config.ContainerDaemonSocket, "/var/run/docker.sock"),
 	}
 
 	mounts := map[string]string{

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -92,7 +92,7 @@ func (sc *StepContext) Executor() common.Executor {
 		remoteAction.URL = rc.Config.GitHubInstance
 
 		github := rc.getGithubContext()
-		if remoteAction.IsCheckout() && github.isLocalCheckout(step) {
+		if remoteAction.IsCheckout() && github.isLocalCheckout(step, rc.ExprEval) {
 			return func(ctx context.Context) error {
 				common.Logger(ctx).Debugf("Skipping local actions/checkout because workdir was already copied")
 				return nil


### PR DESCRIPTION
Applies 3 bug fixes:

- Makes the matrix `include` section work as intended, as laid out [in the docs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-additional-values-into-combinations). (Previously, `includes` only had an effect if they had keys in common with an existing matrix entry, and they always added new entries instead of modifying existing ones.)
- Evaluate checkout refs when determining if a checkout is local. If a workflow uses `actions/checkout` with a variable ref (e.g. `ref: {{ github.head-ref }}`, then the runner should check whether the given ref evaluates to the ref of the current repo when determining if a checkout is local.
- Stops the runner from binding `/var/run/docker.sock` in the runner container. This is a security risk, since it gives workflows the ability to affect the host machine. Runners should be completely isolated from the host.